### PR TITLE
collapse spaces and line breaks

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -64,6 +64,13 @@ export function convert(html: string, options: { indent: { with: string, size: n
         depth--;
         elm += ']';
     };
+    let postParseOps = (elmCode): string => {
+        return utils.ariaToAttributes(
+            utils.dataToAttributes(
+                utils.fixTypeDeclaration(elmCode)
+            )
+        );
+    };
     let parser = new Parser({
         onopentag: onOpenTag,
         ontext: onText,
@@ -72,5 +79,5 @@ export function convert(html: string, options: { indent: { with: string, size: n
 
     parser.write(html);
     parser.end('');
-    return elm;
+    return postParseOps(elm);
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import {Parser} from 'htmlparser2';
+import { Parser } from 'htmlparser2';
 import * as utils from './utils';
 
 
@@ -20,6 +20,7 @@ export function convert(html: string, options: { indent: { with: string, size: n
     let indentWith = options.indent.with;
     let depth = -1;
     let context = [];
+    html = utils.sanitizeHtml(html);
     let onOpenTag = (name: string, attributes: any): void => {
         let pre = '';
         let tag = [];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,3 +23,24 @@ function collapseSpaces(value: string): string {
 
     return collapsedValue;
 }
+
+
+export function ariaToAttributes(value: string): string {
+    let
+        regex = /(aria-.+?)\s/gm,
+        ariaAsAttributes = value.replace(regex, 'attribute "$1" ');
+
+    return ariaAsAttributes;
+}
+
+export function dataToAttributes(value: string): string {
+    let
+        regex = /(data-.+?)\s/gm,
+        dataAsAttributes = value.replace(regex, 'attribute "$1" ');
+
+    return dataAsAttributes;
+}
+
+export function fixTypeDeclaration(value: string): string {
+    return value.replace(/type'/, "type_");
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,3 +11,15 @@ export function styleToElm(value: string): string[] {
         return '( "' + arr.join('", "') + '" )';
     });
 }
+
+export function sanitizeHtml(value: string): string {
+    return collapseSpaces(value);
+}
+
+function collapseSpaces(value: string): string {
+    let
+        regex = /(\s{2,}|\n)/gm,
+        collapsedValue = value.replace(regex, ' ');
+
+    return collapsedValue;
+}


### PR DESCRIPTION
Added a collapseSpaces method in util that removes double spacing and line endings. This helps eliminate unecessary text nodes being generated in elm