### PR TITLE
Fixed type_ attribute in parser

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -29,7 +29,7 @@ export function convert(html: string, options: { indent: { with: string, size: n
                 return attribute + ' [ ' + utils.styleToElm(value).join(', ') + ' ]';
             }
             if (attribute === 'type') {
-                attribute = 'type\'';
+                attribute = 'type_';
             }
             return attribute + ' "' + value + '"';
         });


### PR DESCRIPTION
Currently `type` is converted to `type'`. It should be `type_`. I think this changed over different elm versions.

#### Documentation
http://package.elm-lang.org/packages/elm-lang/html/2.0.0/Html-Attributes#type_